### PR TITLE
Migrate from HTML::Tidy to HTML::Tidy5

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+[Changes for 0.34 - Tue Jul 23 20:00:23 EAT 2024]
+
+* Migrated from HTML::Tidy to HTML::Tidy5 for enhanced HTML5 support and because tidyp is no longer maintained.
+
 [Changes for 0.33 - Wed Oct 23 20:00:23 EAT 2019]
 
 * Fix META.yml and README; no functional changes.

--- a/META.yml
+++ b/META.yml
@@ -21,10 +21,10 @@ no_index:
 provides:
   PDF::FromHTML:
     file: lib/PDF/FromHTML.pm
-    version: '0.33'
+    version: '0.34'
   PDF::FromHTML::Template:
     file: lib/PDF/FromHTML/Template.pm
-    version: '0.33'
+    version: '0.34'
   PDF::FromHTML::Template::Base:
     file: lib/PDF/FromHTML/Template/Base.pm
   PDF::FromHTML::Template::Constants:
@@ -87,7 +87,7 @@ provides:
     file: lib/PDF/FromHTML/Twig.pm
 requires:
   Graphics::ColorNames: 0
-  HTML::Tidy: 0
+  HTML::Tidy5: 0
   Image::Size: 0
   LWP::Simple: 0
   List::Util: 0
@@ -95,4 +95,4 @@ requires:
   PDF::Writer: '0.05'
   XML::Twig: 0
   perl: 5.6.0
-version: '0.33'
+version: '0.34'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,10 +34,10 @@ unless (can_use('PDF::API2') or can_use('pdflib_pl')) {
     }
 }
 
-unless (can_use('HTML::Tidy') or can_use('XML::Clean')) {
-    requires 'HTML::Tidy';
+unless (can_use('HTML::Tidy5') or can_use('XML::Clean')) {
+    requires 'HTML::Tidy5';
     print << '.';
-*** If you cannot install HTML::Tidy, you may use the XML::Clean
+*** If you cannot install HTML::Tidy5, you may use the XML::Clean
     module instead; however, you will run probably run into more
     "XML not well-formed" errors that way.
 .

--- a/lib/PDF/FromHTML.pm
+++ b/lib/PDF/FromHTML.pm
@@ -4,7 +4,7 @@ use 5.006;
 use strict;
 use warnings;
 
-our $VERSION = '0.33';
+our $VERSION = '0.34';
 
 BEGIN {
     foreach my $method ( qw( pdf twig tidy args ) ) {
@@ -35,11 +35,11 @@ use constant PDF_WRITER_BACKEND => do {
 };
 use constant HAS_HTML_TIDY => do {
     local $@;
-    eval { require HTML::Tidy; 1 } or do {
+    eval { require HTML::Tidy5; 1 } or do {
         unless ( eval { require XML::Clean; 1 } ) {
-            die( "Please install HTML::Tidy (preferred) or XML::Clean first" );
+            die( "Please install HTML::Tidy5 (preferred) or XML::Clean first" );
         }
-        0; # Has XML::Clean but no HTML::Tidy
+        0; # Has XML::Clean but no HTML::Tidy5
     };
 };
 
@@ -125,7 +125,7 @@ sub parse_file {
         if (HAS_UNICODE_SUPPORT()) {
             $content = Encode::encode( ascii => $content, Encode::FB_XMLCREF());
         }
-        $content = HTML::Tidy->new->clean(
+        $content = HTML::Tidy5->new->clean(
             '<?xml version="1.0" encoding="UTF-8"?>',
             '<html xmlns="http://www.w3.org/1999/xhtml">',
             $content,

--- a/lib/PDF/FromHTML/Template.pm
+++ b/lib/PDF/FromHTML/Template.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base 'PDF::FromHTML::Template::Base';
 
-our $VERSION = '0.33';
+our $VERSION = '0.34';
 
 use PDF::Writer;
 


### PR DESCRIPTION
Migrate from HTML::Tidy to HTML::Tidy5 for enhanced HTML5 support because tidyp is no longer maintained